### PR TITLE
Simplified the driver for BrowserKitDriver 1.0.5

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -16,8 +16,7 @@
 
     "require": {
         "php":                           ">=5.3.1",
-        "behat/mink":                    "~1.4.3",
-        "behat/mink-browserkit-driver":  "~1.0.4",
+        "behat/mink-browserkit-driver":  "~1.0,>=1.0.5",
         "fabpot/goutte":                 "~1.0.1"
     },
 

--- a/src/Behat/Mink/Driver/GoutteDriver.php
+++ b/src/Behat/Mink/Driver/GoutteDriver.php
@@ -52,24 +52,6 @@ class GoutteDriver extends BrowserKitDriver
     }
 
     /**
-     * Returns last response headers.
-     *
-     * @return array
-     */
-    public function getResponseHeaders()
-    {
-        return $this->getClient()->getResponse()->getHeaders();
-    }
-
-    /**
-     * {@inheritdoc}
-     */
-    public function getStatusCode()
-    {
-        return $this->getClient()->getResponse()->getStatus();
-    }
-
-    /**
      * Prepares URL for visiting.
      *
      * @param string $url


### PR DESCRIPTION
This simplifies the drivers thanks to changes done in https://github.com/Behat/MinkBrowserKitDriver/pull/15

It also simplifies the composer requirement, allowing to have a single version compatible with both BrowserKitDriver 1.0.5+ (for Mink 1.4) and [BrowserKitDriver 1.1](https://github.com/Behat/MinkBrowserKitDriver/pull/16) (for Mink 1.5) by letting BrowserKitDriver define the Mink requirement.
the composer installation will fail on Travis because of the minimum stability right now as 1.0.5 is not tagged yet in the BrowserKitDriver so only the dev version could match the constraint right now.
