### PR TITLE
Bump Goutte version to latest 1.0.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php":                           ">=5.3.1",
         "behat/mink-browserkit-driver":  ">=1.0.5,<1.2.0",
-        "fabpot/goutte":                 "~1.0.1"
+        "fabpot/goutte":                 "~1.0"
     },
 
     "autoload": {


### PR DESCRIPTION
Hello,

This PR loosen the version contraint on the fabpot/Goutte dependency, allowing to use the latest version of it. 

The final aim is to be able to use latests version of guzzle/guzzle, as latest version of Goutte loosen its version constraints on it too :)
