### PR TITLE
Added resetting of the basic auth

### DIFF
--- a/src/Behat/Mink/Driver/GoutteDriver.php
+++ b/src/Behat/Mink/Driver/GoutteDriver.php
@@ -54,6 +54,15 @@ class GoutteDriver extends BrowserKitDriver
     /**
      * {@inheritdoc}
      */
+    public function reset()
+    {
+        parent::reset();
+        $this->getClient()->resetAuth();
+    }
+
+    /**
+     * {@inheritdoc}
+     */
     protected function prepareUrl($url)
     {
         return $url;


### PR DESCRIPTION
this makes the driver pass the test added in https://github.com/Behat/Mink/pull/511

I also added an overwrite of the client getter to document that the client returned by the getter is always a Goutte client, not a generic BrowserKit client
