### PR TITLE
Added tests covering the 2 ways to instantiate the driver

### DIFF
--- a/tests/Behat/Mink/Driver/ExtraDriverTest.php
+++ b/tests/Behat/Mink/Driver/ExtraDriverTest.php
@@ -1,0 +1,30 @@
+<?php
+
+namespace Tests\Behat\Mink\Driver;
+
+use Behat\Mink\Driver\GoutteDriver;
+
+/**
+ * @group unit
+ */
+class ExtraDriverTest extends \PHPUnit_Framework_TestCase
+{
+    public function testInstantiateWithClient()
+    {
+        $client = $this->getMockBuilder('Behat\Mink\Driver\Goutte\Client')->disableOriginalConstructor()->getMock();
+        $client->expects($this->once())
+            ->method('followRedirects')
+            ->with(true);
+
+        $driver = new GoutteDriver($client);
+
+        $this->assertSame($client, $driver->getClient());
+    }
+
+    public function testInstantiateWithoutClient()
+    {
+        $driver = new GoutteDriver();
+
+        $this->assertInstanceOf('Behat\Mink\Driver\Goutte\Client', $driver->getClient());
+    }
+}

--- a/tests/Behat/Mink/Driver/GoutteDriverTest.php
+++ b/tests/Behat/Mink/Driver/GoutteDriverTest.php
@@ -5,7 +5,7 @@ namespace Tests\Behat\Mink\Driver;
 use Behat\Mink\Driver\GoutteDriver;
 
 /**
- * @group gouttedriver
+ * @group functional
  */
 class GoutteDriverTest extends GeneralDriverTest
 {


### PR DESCRIPTION
I added the extra unit tests as a separate testcase to ensure we won't hide some test from the common driver testsuite by mistake (it was the case at some point in MinkSeleniumDriver IIRC)
