### PR TITLE
Changed the typehint to allow using a normal Goutte client

### DIFF
--- a/src/Behat/Mink/Driver/GoutteDriver.php
+++ b/src/Behat/Mink/Driver/GoutteDriver.php
@@ -10,7 +10,8 @@
 
 namespace Behat\Mink\Driver;
 
-use Behat\Mink\Driver\Goutte\Client;
+use Behat\Mink\Driver\Goutte\Client as ExtendedClient;
+use Goutte\Client;
 
 /**
  * Goutte driver.
@@ -26,7 +27,7 @@ class GoutteDriver extends BrowserKitDriver
      */
     public function __construct(Client $client = null)
     {
-        parent::__construct($client ?: new Client());
+        parent::__construct($client ?: new ExtendedClient());
     }
 
     /**
@@ -45,9 +46,9 @@ class GoutteDriver extends BrowserKitDriver
 
     /**
      * Gets the Goutte client.
-     * 
+     *
      * The method is overwritten only to provide the appropriate return type hint.
-     * 
+     *
      * @return Client
      */
     public function getClient()

--- a/tests/Custom/InstantiationTest.php
+++ b/tests/Custom/InstantiationTest.php
@@ -4,14 +4,11 @@ namespace Behat\Mink\Tests\Driver\Custom;
 
 use Behat\Mink\Driver\GoutteDriver;
 
-/**
- * @group unit
- */
 class InstantiationTest extends \PHPUnit_Framework_TestCase
 {
     public function testInstantiateWithClient()
     {
-        $client = $this->getMockBuilder('Behat\Mink\Driver\Goutte\Client')->disableOriginalConstructor()->getMock();
+        $client = $this->getMockBuilder('Goutte\Client')->disableOriginalConstructor()->getMock();
         $client->expects($this->once())
             ->method('followRedirects')
             ->with(true);


### PR DESCRIPTION
The extended client shipped with the driver was implemented to detect the content-type based on the HTML meta tag when the header is not set. As the feature has been merged in DomCrawler in Symfony 2.2.7, it makes sense to allow passing a normal Goutte instance now.

When moving to Mink 2.0, the extended client class will be removed, as BrowserKitDriver 2.0 will require BrowserKit 2.3+, so we can require DomCrawler 2.3+ too.
In the 1.x branch, I'm keeping the extended client for the default instantiation to be sure to preserve BC for people who don't build the client explicitly.
