### PR TITLE
Use actual working example in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -35,6 +35,8 @@ echo $session->getCurrentUrl() . PHP_EOL;
 Installation
 ------------
 
+Add a file composer.json with content:
+
 ``` json
 {
     "require": {
@@ -43,6 +45,8 @@ Installation
     }
 }
 ```
+
+(or merge the above into your project's existing composer.json file)
 
 ``` bash
 $> curl -sS https://getcomposer.org/installer | php


### PR DESCRIPTION
- Passing $startUrl to the constructor of `Behat\Mink\Driver\Goutte\Client` didn't work.
- example.com doesn't have a "Chat" button to click.
- When it did work, no feedback was given to indicate anything actually happened - this example will print a URL of a download page on php.net
