### PR TITLE
Update to use Goutte 3.0

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.3, 5.4, 5.5, 5.6, hhvm]
+php: [5.5, 5.6, hhvm]
 
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,6 @@
 language: php
 
-php: [5.5, 5.6, hhvm]
+php: [5.3, 5.4, 5.5, 5.6, hhvm]
 
 before_script:
   - export WEB_FIXTURES_HOST=http://localhost

--- a/composer.json
+++ b/composer.json
@@ -15,10 +15,10 @@
     ],
 
     "require": {
-        "php":                           ">=5.3.1",
+        "php":                           ">=5.5.0",
         "behat/mink":                    "~1.6@dev",
         "behat/mink-browserkit-driver":  "~1.2@dev",
-        "fabpot/goutte":                 "~1.0.4|~2.0"
+        "fabpot/goutte":                 ">=1.0.4,<4.0.0"
     },
 
     "autoload": {

--- a/composer.json
+++ b/composer.json
@@ -15,7 +15,7 @@
     ],
 
     "require": {
-        "php":                           ">=5.5.0",
+        "php":                           ">=5.3.1",
         "behat/mink":                    "~1.6@dev",
         "behat/mink-browserkit-driver":  "~1.2@dev",
         "fabpot/goutte":                 ">=1.0.4,<4.0.0"

--- a/composer.json
+++ b/composer.json
@@ -18,7 +18,7 @@
         "php":                           ">=5.3.1",
         "behat/mink":                    "~1.6@dev",
         "behat/mink-browserkit-driver":  "~1.2@dev",
-        "fabpot/goutte":                 ">=1.0.4,<4.0.0"
+        "fabpot/goutte":                 "~1.0.4|~2.0|~3.1"
     },
 
     "autoload": {


### PR DESCRIPTION
Goutte 3.0 was [recently released](https://github.com/FriendsOfPHP/Goutte/pull/218) to support Guzzle 6.0. Since Drupal 8 is moving to Guzzle 6, and hence Goutte 3.0, we also need a corresponding release of MinkGoutteDriver that can work with them.