### PR TITLE
Require-dev phpunit

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,10 @@
         "fabpot/goutte":                 "~1.0.4|~2.0"
     },
 
+    "require-dev": {
+        "phpunit/phpunit": "^4.0"
+    },
+
     "autoload": {
         "psr-4": {
             "Behat\\Mink\\Driver\\": "src/"


### PR DESCRIPTION
I am not sure if it is a conscious decision to not include PHPUnit in required-dev section of composer.json. I had to add it temporarily while debugging test failures for another issue and I thought why not just add it.

If it was deliberate to not add it, I would very much like to know the reason.