### PR TITLE
Expand fabpot/goutte Composer version constraint to include 4.x

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php":                           ">=5.4",
         "behat/mink-browserkit-driver":  "~1.2@dev",
-        "fabpot/goutte":                 "~1.0.4|~2.0|~3.1"
+        "fabpot/goutte":                 "~1.0.4|~2.0|~3.1|~4.0"
     },
 
     "require-dev": {


### PR DESCRIPTION
The `fabpot/goutte` project recently cut a new 4.x branch (with an initial [4.0.0](https://github.com/FriendsOfPHP/Goutte/releases/tag/v4.0.0) release) to remove Guzzle. Can we update the dependency to allow the new version?