### PR TITLE
Add support for Goutte 4

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,7 @@
     "require": {
         "php":                           ">=5.4",
         "behat/mink-browserkit-driver":  "~1.2@dev",
-        "fabpot/goutte":                 "~1.0.4|~2.0|~3.1"
+        "fabpot/goutte":                 "~1.0.4|~2.0|~3.1|~4.0"
     },
 
     "require-dev": {

--- a/src/GoutteDriver.php
+++ b/src/GoutteDriver.php
@@ -12,6 +12,7 @@ namespace Behat\Mink\Driver;
 
 use Behat\Mink\Driver\Goutte\Client as ExtendedClient;
 use Goutte\Client;
+use Symfony\Component\BrowserKit\HttpBrowser;
 
 /**
  * Goutte driver.
@@ -35,6 +36,11 @@ class GoutteDriver extends BrowserKitDriver
      */
     public function setBasicAuth($user, $password)
     {
+        if ($this->isClientHttpBrowser()) {
+            parent::setBasicAuth($user, $password);
+
+            return;
+        }
         if (false === $user) {
             $this->getClient()->resetAuth();
 
@@ -62,7 +68,9 @@ class GoutteDriver extends BrowserKitDriver
     public function reset()
     {
         parent::reset();
-        $this->getClient()->resetAuth();
+        if (!$this->isClientHttpBrowser()) {
+            $this->getClient()->resetAuth();
+        }
     }
 
     /**
@@ -78,5 +86,18 @@ class GoutteDriver extends BrowserKitDriver
             );
         }
         return $url;
+    }
+
+    /**
+     * Indicates whether the client is an instance of HttpBrowser
+     *
+     * As of Goutte version 4.0, the client is just an unmodified extension of
+     * the HttpBrowser class from BrowserKit.
+     *
+     * @return bool
+     */
+    protected function isClientHttpBrowser()
+    {
+        return ($this->getClient() instanceof HttpBrowser);
     }
 }

--- a/src/GoutteDriver.php
+++ b/src/GoutteDriver.php
@@ -96,7 +96,7 @@ class GoutteDriver extends BrowserKitDriver
      *
      * @return bool
      */
-    protected function isClientHttpBrowser()
+    private function isClientHttpBrowser()
     {
         return ($this->getClient() instanceof HttpBrowser);
     }

--- a/src/GoutteDriver.php
+++ b/src/GoutteDriver.php
@@ -41,6 +41,7 @@ class GoutteDriver extends BrowserKitDriver
 
             return;
         }
+
         if (false === $user) {
             $this->getClient()->resetAuth();
 
@@ -68,6 +69,7 @@ class GoutteDriver extends BrowserKitDriver
     public function reset()
     {
         parent::reset();
+
         if (!$this->isClientHttpBrowser()) {
             $this->getClient()->resetAuth();
         }


### PR DESCRIPTION
Related to #80 and #85.

This adds goutte 4 to the list of versions that satisfy this package's
requirements and updates the driver's implementation to account for the
new version's updates. Since the client in v4 is just an unmodified
extension of HttpBrowser from browserkit, the driver can just defer to
the BrowserKitDriver's implementation.

I ran the test suite with PHP 7.4 and 8.0 and with goutte 3.3 and 4.0 with no failing tests, but we'll see what the tests for the PR say here 😅